### PR TITLE
Fix malformed JSON example

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,55 +5,55 @@ Rotonde is a decentralized social network built upon on [dat](https://datproject
 ### The JSON structure for the Rotonde API. 
 
 In the root directory of the dat there should be a file called `portal.json`. Its contents has the following structure.
-```
+
+```json
 {
   "name": "cblgh",
   "desc": "the p2p web is here",
   "port": [
-    "dat://2f21e3c122ef0f2555d3a99497710cd875c7b0383f998a2d37c02c042d598485/",
-    "dat://7f2ef715c36b6cd226102192ba220c73384c32e4beb49601fb3f5bba4719e0c5/",
-    "dat://223e4ab259fe5c8d622b52025be869f11a726091772f14ab3603d7182442c6eb"
-    ]
-  "feed": [
-      {
-        "message": "welcome to rotonde 2.0", 
-        "timestamp": 1507846364271
-      },
-      {
-        "message": "check https://cblgh.org/rotonde.html for a list of portals to follow", 
-        "media": "webpage-img.png",
-        "timestamp": 1507846314271
-      },
-      {
-        "message": "@neauoire woah that's cool", 
-        "target": "dat://2f21e3c122ef0f2555d3a99497710cd875c7b0383f998a2d37c02c042d598485/",
-        "timestamp": 1507846214271
-      },
-      {
-        "message": "dat is so cooool, thanks https://datproject.org & https://beakerbrowser.com !", 
-        "timestamp": 1507846194271
-        "editstamp": 1507846216271
-      },
-      {
-        "message": "I'm excited for this!",
-        "timestamp": 1508373135785,
-        "target": "dat://60f134e8fb243fbf4a0f8a252cc9aa09bdcf4ecac2efbcb8455aa01c8a04b4b0/index.html",
-        "ref": "17",
-        "quote": {
-          "message": "Have also been scrounging a complex set of arena channels that get at some of the ecosystem that exists around rotonde that I'll share shortly",
-         "timestamp": 1508371261682
-    },
-      {
-        "message": "psst!",
-        "timestamp": 1508381644692,
-        "target": "dat://c1ae9f8b1b10a0df968a157c8b35cd8b32266c657d3aa767751895568146bed4/",
-        "whisper": true
-    }
-
-},
+    "dat:\/\/2f21e3c122ef0f2555d3a99497710cd875c7b0383f998a2d37c02c042d598485\/",
+    "dat:\/\/7f2ef715c36b6cd226102192ba220c73384c32e4beb49601fb3f5bba4719e0c5\/",
+    "dat:\/\/223e4ab259fe5c8d622b52025be869f11a726091772f14ab3603d7182442c6eb"
   ],
-  "dat": "dat://7f2ef715c36b6cd226102192ba220c73384c32e4beb49601fb3f5bba4719e0c5",
-  "site": "https://cblgh.org"
+  "feed": [
+    {
+      "message": "welcome to rotonde 2.0",
+      "timestamp": 1507846364271
+    },
+    {
+      "message": "check https:\/\/cblgh.org\/rotonde.html for a list of portals to follow",
+      "media": "webpage-img.png",
+      "timestamp": 1507846314271
+    },
+    {
+      "message": "@neauoire woah that's cool",
+      "target": "dat:\/\/2f21e3c122ef0f2555d3a99497710cd875c7b0383f998a2d37c02c042d598485\/",
+      "timestamp": 1507846214271
+    },
+    {
+      "message": "dat is so cooool, thanks https:\/\/datproject.org & https:\/\/beakerbrowser.com !",
+      "timestamp": 1507846194271,
+      "editstamp": 1507846216271
+    },
+    {
+      "message": "I'm excited for this!",
+      "timestamp": 1508373135785,
+      "target": "dat:\/\/60f134e8fb243fbf4a0f8a252cc9aa09bdcf4ecac2efbcb8455aa01c8a04b4b0\/index.html",
+      "ref": "17",
+      "quote": {
+        "message": "Have also been scrounging a complex set of arena channels that get at some of the ecosystem that exists around rotonde that I'll share shortly",
+        "timestamp": 1508371261682
+      }
+    },
+    {
+      "message": "psst!",
+      "timestamp": 1508381644692,
+      "target": "dat:\/\/c1ae9f8b1b10a0df968a157c8b35cd8b32266c657d3aa767751895568146bed4\/",
+      "whisper": true
+    }
+  ],
+  "dat": "dat:\/\/7f2ef715c36b6cd226102192ba220c73384c32e4beb49601fb3f5bba4719e0c5",
+  "site": "https:\/\/cblgh.org"
 }
 ```
 


### PR DESCRIPTION
This fixes a few instances of malformed JSON syntax in the `portal.json` example. I know that PRs for small stuff like this can annoy some people. I thought it was worth doing here because someone (like myself) might copy/paste the JSON example into a text file in order to start playing around with the protocol.